### PR TITLE
Add handling for digits with text. Fixes #5

### DIFF
--- a/IndefiniteArticle.class.php
+++ b/IndefiniteArticle.class.php
@@ -61,7 +61,7 @@ class IndefiniteArticle
 
 			#first strip off any decimals and remove spaces or commas
 			#then if the number of digits modulus 3 is 2 we have a match
-			if(strlen(preg_replace(array("/\s/", "/,/", "/\.(\d+)?/"), '', $word))%3 == 2) return "an $word";
+			if(strlen(preg_replace(array("/\s/", "/,/", "/\.(\d+)?/", "/[-_a-zA-Z]/"), '', $word))%3 == 2) return "an $word";
 		}
 
 		# HANDLE ORDINAL FORMS

--- a/test.php
+++ b/test.php
@@ -2,7 +2,7 @@
 
 require_once("IndefiniteArticle.class.php");
 
-$testWords = array("umbrella", "hour", "American", "German", "Ukrainian", "Uzbekistani", "euphenism", "Euler number");
+$testWords = array("umbrella", "hour", "American", "German", "Ukrainian", "Uzbekistani", "euphenism", "Euler number", "11 Degrees T-shirt", "18", "1800");
 
 foreach($testWords as $word) {
 	echo "$word => ".IndefiniteArticle::A($word)."<br>\n";


### PR DESCRIPTION
When a string starts with "11" or "18", we check if the length of the string %3 == 2. Spaces and decimals were previously filtered out but letters and dashes were not. This PR also filters those out so that it will correctly return "an 11 Degrees T-shirt".